### PR TITLE
refactor(core): disable customer id and staff id duplicated

### DIFF
--- a/src/core/data/struct/linkedlist.h
+++ b/src/core/data/struct/linkedlist.h
@@ -24,7 +24,8 @@ template<typename T>
 class LinkedList;
 
 template<typename T>
-class LinkedListIter {
+class LinkedListIter : public std::iterator<std::forward_iterator_tag, T> {
+
 public:
     using value_tpye = T;
     using reference = T &;
@@ -33,11 +34,11 @@ public:
     explicit LinkedListIter(pointer init) : Iter(init), end(false) {
     }
 
-    bool operator==(const LinkedListIter &rhs) const  {
+    bool operator==(const LinkedListIter &rhs) const {
         return Iter == rhs.Iter && end == rhs.end;
     }
 
-    bool operator!=(const LinkedListIter &rhs) const  {
+    bool operator!=(const LinkedListIter &rhs) const {
         return Iter != rhs.Iter || end != rhs.end;
     }
 
@@ -97,7 +98,7 @@ private:
     }
 
 public:
-    LinkedList() : first(nullptr), last(nullptr) , nodeNum(0){
+    LinkedList() : first(nullptr), last(nullptr), nodeNum(0) {
     }
 
     void clear() {
@@ -213,7 +214,8 @@ public:
     bool empty() {
         return first == nullptr && last == nullptr;
     }
-    std::size_t size(){
+
+    std::size_t size() {
         return nodeNum;
     }
 

--- a/src/core/page/custom_account.cpp
+++ b/src/core/page/custom_account.cpp
@@ -56,7 +56,19 @@ void customerAccountAddPage(tui::Term &term) {
                                             [&term, &number, &name, &telephone, &id, &isVIP, &pwd](WTextButton &btn) {
                                                 btn.setFocusOrder(6);
                                                 btn.setActionListener(
+
                                                         [&term, &number, &name, &telephone, &id, &isVIP, &pwd] {
+                                                            auto &db = Database::getInstance()->customer;
+                                                            if (db.end() != std::find_if(db.begin(), db.end(),
+                                                                                         [&number](const Customer &c) {
+                                                                                             return c.cardID ==
+                                                                                                    number.data();
+                                                                                         })) {
+                                                                msgbox<wchar_t, wchar_t, wchar_t>(term, L"该卡号已存在",
+                                                                                                  true, L"确定", false,
+                                                                                                  L"");
+                                                                return;
+                                                            }
                                                             Customer newCustomer{
                                                                     number.data(),
                                                                     pwd.data(),
@@ -66,7 +78,7 @@ void customerAccountAddPage(tui::Term &term) {
                                                                     isVIP,
                                                                     {}, {}
                                                             };
-                                                            Database::getInstance()->customer.push_back(newCustomer);
+                                                            db.push_back(newCustomer);
                                                             term.pop();
                                                         });
                                             }, L"添加"),
@@ -89,8 +101,6 @@ void customerAccountAddPage(tui::Term &term) {
 
 void customerAccountEditPage(tui::Term &term, Customer &customer) {
     using namespace tui;
-    std::vector<char> number(customer.cardID.begin(), customer.cardID.end());
-    number.push_back('\0');
 
     std::vector<char> name(customer.name.begin(), customer.name.end());
     name.push_back('\0');
@@ -109,26 +119,23 @@ void customerAccountEditPage(tui::Term &term, Customer &customer) {
             ui<VListView>(
                     ui<Box>(
                             ui<Table<2>>(
-                                    tableRow(ui<WText>(L"卡号:"), ui_args<TextField>([](TextField &b) {
-                                        b.setFocusOrder(0);
-                                    }, &number, 20)),
                                     tableRow(ui<WText>(L"原密码:"), ui_args<TextField>([](TextField &b) {
-                                        b.setFocusOrder(1);
+                                        b.setFocusOrder(0);
                                     }, &oldPwd, 20)),
                                     tableRow(ui<WText>(L"新密码:"), ui_args<TextField>([](TextField &b) {
-                                        b.setFocusOrder(2);
+                                        b.setFocusOrder(1);
                                     }, &newPwd, 20)),
                                     tableRow(ui<WText>(L"姓名:"), ui_args<TextField>([](TextField &b) {
-                                        b.setFocusOrder(3);
+                                        b.setFocusOrder(2);
                                     }, &name, 20)),
                                     tableRow(ui<WText>(L"电话:"), ui_args<TextField>([](TextField &b) {
-                                        b.setFocusOrder(4);
+                                        b.setFocusOrder(3);
                                     }, &telephone, 20)),
                                     tableRow(ui<WText>(L"身份证:"), ui_args<TextField>([](TextField &b) {
-                                        b.setFocusOrder(5);
+                                        b.setFocusOrder(4);
                                     }, &id, 20)),
                                     tableRow(ui<Text>(" VIP:"), ui_args<Checkbox>([](Checkbox &b) {
-                                        b.setFocusOrder(6);
+                                        b.setFocusOrder(5);
                                     }, &isVIP))
 
                             )
@@ -137,11 +144,11 @@ void customerAccountEditPage(tui::Term &term, Customer &customer) {
                     ui<HCenter>(
                             ui<HListView>(
                                     ui_args<WTextButton>(
-                                            [&term, &number, &name, &telephone, &id, &isVIP, &customer, &newPwd, &oldPwd](
+                                            [&term, &name, &telephone, &id, &isVIP, &customer, &newPwd, &oldPwd](
                                                     WTextButton &btn) {
-                                                btn.setFocusOrder(7);
+                                                btn.setFocusOrder(6);
                                                 btn.setActionListener(
-                                                        [&term, &number, &name, &telephone, &id, &isVIP, &customer, &oldPwd, &newPwd] {
+                                                        [&term, &name, &telephone, &id, &isVIP, &customer, &oldPwd, &newPwd] {
                                                             if (std::string(oldPwd.data()) != customer.password) {
                                                                 msgbox<wchar_t, wchar_t, wchar_t>(term, L"密码错误",
                                                                                                   true, L"确定", false,
@@ -151,7 +158,6 @@ void customerAccountEditPage(tui::Term &term, Customer &customer) {
                                                             if (newPwd.size() > 1) {
                                                                 customer.password = newPwd.data();
                                                             }
-                                                            customer.cardID = number.data();
                                                             customer.id = id.data();
                                                             customer.telephone = telephone.data();
                                                             customer.name = name.data();
@@ -161,7 +167,7 @@ void customerAccountEditPage(tui::Term &term, Customer &customer) {
                                             }, L"应用"),
                                     ui<Struct>(1, 3),
                                     ui_args<WTextButton>([&term](WTextButton &btn) {
-                                        btn.setFocusOrder(8);
+                                        btn.setFocusOrder(7);
                                         btn.setActionListener([&term] {
                                             term.pop();
                                         });

--- a/src/core/page/staff_manager.cpp
+++ b/src/core/page/staff_manager.cpp
@@ -51,6 +51,28 @@ void staffAddManager(tui::Term &term) {
                                             [&term, &number, &name, &telephone, &id, &level](WTextButton &btn) {
                                                 btn.setFocusOrder(5);
                                                 btn.setActionListener([&term, &number, &name, &telephone, &id, &level] {
+                                                    auto &db = Database::getInstance()->staff;
+                                                    if (db.end() != std::find_if(db.begin(), db.end(),
+                                                                                 [&number](const Staff &c) {
+                                                                                     return c.cardID ==
+                                                                                            number.data();
+                                                                                 })) {
+                                                        msgbox<wchar_t, wchar_t, wchar_t>(term, L"该编号已被占用",
+                                                                                          true, L"确定", false,
+                                                                                          L"");
+                                                        return;
+                                                    }
+
+                                                    if (db.end() != std::find_if(db.begin(), db.end(),
+                                                                                 [&id](const Staff &c) {
+                                                                                     return c.cardID ==
+                                                                                            id.data();
+                                                                                 })) {
+                                                        msgbox<wchar_t, wchar_t, wchar_t>(term, L"该职工已存在",
+                                                                                          true, L"确定", false,
+                                                                                          L"");
+                                                        return;
+                                                    }
                                                     Staff staff{
                                                             number.data(),
                                                             name.data(),
@@ -81,9 +103,6 @@ void staffAddManager(tui::Term &term) {
 
 void staffEditPage(tui::Term &term, Staff &staff) {
     using namespace tui;
-    std::vector<char> number(staff.cardID.begin(), staff.cardID.end());
-    number.push_back('\0');
-
     std::vector<char> name(staff.name.begin(), staff.name.end());
     name.push_back('\0');
 
@@ -100,20 +119,17 @@ void staffEditPage(tui::Term &term, Staff &staff) {
             ui<VListView>(
                     ui<Box>(
                             ui<Table<2>>(
-                                    tableRow(ui<WText>(L"员工编号:"), ui_args<TextField>([](TextField &b) {
-                                        b.setFocusOrder(0);
-                                    }, &number, 20)),
                                     tableRow(ui<WText>(L"姓名:"), ui_args<TextField>([](TextField &b) {
-                                        b.setFocusOrder(1);
+                                        b.setFocusOrder(0);
                                     }, &name, 20)),
                                     tableRow(ui<WText>(L"电话:"), ui_args<TextField>([](TextField &b) {
-                                        b.setFocusOrder(2);
+                                        b.setFocusOrder(1);
                                     }, &telephone, 20)),
                                     tableRow(ui<WText>(L"身份证:"), ui_args<TextField>([](TextField &b) {
-                                        b.setFocusOrder(3);
+                                        b.setFocusOrder(2);
                                     }, &id, 20)),
                                     tableRow(ui<WText>(L"职位:"), ui_args<TextField>([](TextField &b) {
-                                        b.setFocusOrder(4);
+                                        b.setFocusOrder(3);
                                     }, &level, 20))
                             )
                     ),
@@ -121,21 +137,20 @@ void staffEditPage(tui::Term &term, Staff &staff) {
                     ui<HCenter>(
                             ui<HListView>(
                                     ui_args<WTextButton>(
-                                            [&term, &number, &name, &telephone, &id, &level, &staff](WTextButton &btn) {
-                                                btn.setFocusOrder(5);
+                                            [&term, &name, &telephone, &id, &level, &staff](WTextButton &btn) {
+                                                btn.setFocusOrder(4);
                                                 btn.setActionListener(
-                                                        [&term, &number, &name, &telephone, &id, &level, &staff] {
-                                                            staff.cardID = number.data();
+                                                        [&term, &name, &telephone, &id, &level, &staff] {
                                                             staff.name = name.data();
                                                             staff.telephone = telephone.data();
                                                             staff.id = id.data();
                                                             staff.level = level.data();
                                                             term.pop();
                                                         });
-                                            }, L"添加"),
+                                            }, L"修改"),
                                     ui<Struct>(1, 3),
                                     ui_args<WTextButton>([&term](WTextButton &btn) {
-                                        btn.setFocusOrder(6);
+                                        btn.setFocusOrder(5);
                                         btn.setActionListener([&term] {
                                             term.pop();
                                         });


### PR DESCRIPTION
- 链表迭代器追加 `std::forward_iterator_tag` 以适配 STL
- 添加客户时不允许客户卡号重复
- 修改客户信息时不允许编辑客户卡号
- 添加职员时不允许职员编号重复
- 添加职员时不允许职员身份证号重复
- 修改职员信息时不允许修改职员编号
- 修复职员编辑界面的按钮文字错误


Signed-off-by: mslxl <i@mslxl.com>